### PR TITLE
Add BlogComponent to homepage with dummy blog posts

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 import HeroComponent from "@/components/home/hero.component";
 import NewsComponent from "@/components/home/news/news.component";
+import BlogComponent from "@/components/home/blog/blog.component";
 
 export default function Home() {
     return (
         <>
             <HeroComponent/>
             <NewsComponent />
+            <BlogComponent />
         </>
     );
 }

--- a/src/components/home/blog/blog.component.tsx
+++ b/src/components/home/blog/blog.component.tsx
@@ -1,0 +1,89 @@
+'use client'
+import {FC} from "react";
+import {motion} from "framer-motion";
+import {BlogPost} from "@/type";
+import CardComponent from "@/components/home/blog/card.component";
+import TitleComponent from "@/components/home/blog/title.component";
+
+
+const dummyPosts: BlogPost[] = [
+  {
+    id: 1,
+    title: "La Evolución del Desarrollo Web Moderno",
+    excerpt: "Un análisis profundo de las últimas tendencias y tecnologías que están definiendo el futuro del desarrollo web...",
+    category: "Desarrollo Web",
+    readTime: "5 min lectura",
+    date: "2024-03-20",
+    author: {
+      name: "Ana García",
+      avatar: "/hero-image.webp"
+    },
+    image: "/hero-image.webp",
+    tags: ["Web", "Tendencias", "Desarrollo"]
+  },
+  {
+    id: 2,
+    title: "Mejores Prácticas en React 2024",
+    excerpt: "Descubre las técnicas más efectivas para desarrollar aplicaciones React modernas y escalables...",
+    category: "React",
+    readTime: "7 min lectura",
+    date: "2024-03-18",
+    author: {
+      name: "Carlos Ruiz",
+      avatar: "/hero-image.webp"
+    },
+    image: "/hero-image.webp",
+    tags: ["React", "JavaScript", "Frontend"]
+  },
+  {
+    id: 3,
+    title: "Optimización de Rendimiento Web",
+    excerpt: "Guía completa para mejorar el rendimiento de tus aplicaciones web utilizando las últimas técnicas...",
+    category: "Performance",
+    readTime: "6 min lectura",
+    date: "2024-03-15",
+    author: {
+      name: "Laura Martínez",
+      avatar: "/hero-image.webp"
+    },
+    image: "/hero-image.webp",
+    tags: ["Performance", "Web", "Optimización"]
+  }
+];
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.2
+    }
+  }
+};
+
+
+
+const BlogComponent: FC = () => {
+  return (
+    <section className="py-20 bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-accent-100 via-primary-50 to-white">
+      <div className="container mx-auto px-4">
+        <div className="flex flex-col md:flex-row justify-between items-start mb-16">
+         <TitleComponent />
+          <motion.div
+            variants={containerVariants}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2 }}
+            className="md:w-2/3 grid grid-cols-1 md:grid-cols-2 gap-6"
+          >
+            {dummyPosts.map((post, index) => (
+              <CardComponent key={post.id} index={index}  post={post} />
+            ))}
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BlogComponent;

--- a/src/components/home/blog/card.component.tsx
+++ b/src/components/home/blog/card.component.tsx
@@ -1,0 +1,81 @@
+import {FC} from "react";
+import Image from "next/image";
+import {motion} from "framer-motion";
+import {CardBlogComponentProps} from "@/type";
+
+const cardVariants = {
+    hidden: {
+        opacity: 0,
+        y: 20
+    },
+    visible: {
+        opacity: 1,
+        y: 0,
+        transition: {
+            type: "spring",
+            stiffness: 100,
+            damping: 15
+        }
+    }
+};
+
+const CardComponent:FC<CardBlogComponentProps> = ({index, post}) => {
+    return <motion.article
+        key={index}
+        variants={cardVariants}
+        className={`relative overflow-hidden ${
+            index === 0 ? 'md:col-span-2' : ''
+        }`}
+    >
+        <div className="group cursor-pointer">
+            <div className="relative h-64 overflow-hidden rounded-xl">
+                <Image
+                    src={post.image}
+                    alt={post.title}
+                    fill
+                    className="object-cover transition-transform duration-500 group-hover:scale-110"
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                />
+                <div className="absolute inset-0 bg-gradient-to-t from-gray-900 via-gray-900/40 to-transparent opacity-60 group-hover:opacity-70 transition-opacity duration-300" />
+
+                <div className="absolute bottom-0 left-0 right-0 p-6 text-white">
+                      <span className="inline-block px-3 py-1 mb-4 text-xs font-semibold bg-primary-500 rounded-full">
+                        {post.category}
+                      </span>
+
+                    <h3 className="text-xl md:text-2xl font-bold mb-2 transform group-hover:translate-x-2 transition-transform duration-300">
+                        {post.title}
+                    </h3>
+
+                    <div className="flex items-center space-x-4">
+                        <div className="relative w-8 h-8 rounded-full overflow-hidden border-2 border-white">
+                            <Image
+                                src={post.author.avatar}
+                                alt={post.author.name}
+                                fill
+                                className="object-cover"
+                            />
+                        </div>
+                        <div className="text-sm">
+                            <span className="block font-medium">{post.author.name}</span>
+                            <span className="text-gray-300">{post.readTime}</span>
+                        </div>
+                    </div>
+
+                    <div className="flex gap-2 mt-3">
+                        {post.tags.map((tag, tagIndex) => (
+                            <span
+                                key={tagIndex}
+                                className="text-xs px-2 py-1 bg-white/10 rounded-full backdrop-blur-sm"
+                            >
+                            {tag}
+                          </span>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </motion.article>
+}
+
+export default CardComponent;

--- a/src/components/home/blog/title.component.tsx
+++ b/src/components/home/blog/title.component.tsx
@@ -1,0 +1,34 @@
+import {FC} from "react";
+import {motion} from "framer-motion";
+
+const TitleComponent:FC = () => {
+    return  <div className="md:w-1/3 mb-8 md:mb-0">
+        <motion.h2
+            initial={{ opacity: 0, x: -20 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            className="text-5xl font-bold text-white mb-4 leading-tight"
+        >
+            Explora Nuestro
+            <span className="block text-primary-400">Blog Tech</span>
+            <motion.span
+                initial={{ width: 0 }}
+                whileInView={{ width: "100%" }}
+                viewport={{ once: true }}
+                transition={{ delay: 0.5, duration: 0.8 }}
+                className="absolute bottom-0 left-0 h-1 bg-primary-400"
+            />
+        </motion.h2>
+        <motion.p
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.2 }}
+            className="text-lg text-gray-200 pr-8"
+        >
+            Descubre las últimas tendencias, tutoriales y mejores prácticas en desarrollo web y tecnología.
+        </motion.p>
+    </div>
+}
+
+export default TitleComponent;

--- a/src/components/home/news/card.component.tsx
+++ b/src/components/home/news/card.component.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import {motion} from "framer-motion";
 import {FC} from "react";
-import {CardComponentProps} from "@/type";
+import {CardNewsComponentProps} from "@/type";
 
 const cardVariants = {
     hidden: {
@@ -27,7 +27,7 @@ const cardVariants = {
     }
 };
 
-const CardComponent: FC<CardComponentProps> = ({news, index}) => {
+const CardComponent: FC<CardNewsComponentProps> = ({news, index}) => {
     return <motion.article
         variants={cardVariants}
         whileHover="hover"

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -22,9 +22,33 @@ export interface NewsItem {
     category: string;
 }
 
-export interface CardComponentProps {
+export interface CardNewsComponentProps {
     news: NewsItem;
     index: number;
 }
+
+export interface  Author {
+    name: string;
+    avatar: string;
+}
+
+export interface BlogPost {
+    id: number;
+    title: string;
+    excerpt: string;
+    category: string;
+    readTime: string;
+    date: string;
+    author: Author;
+    image: string;
+    tags: string[];
+}
+
+export interface  CardBlogComponentProps {
+    post: BlogPost;
+    index: number;
+}
+
+
 
 


### PR DESCRIPTION
```
### Description of Changes

- Introduced a new `BlogComponent` to the homepage to display dummy blog posts, including title, author, category, and tags.
- Implemented supporting components: `CardComponent` and `TitleComponent` to enhance modularity and maintainability.
- Updated relevant type definitions to support the new structure.

### Checklist

- [ ] Tests added (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] Code adheres to standards/conventions
```