### PR TITLE
Refactor token revalidation and enhance error handling

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -8,12 +8,14 @@ export async function GET(req: NextRequest) {
     try {
         const response = await fetch(`${getEnv(ENV.BACKEND_URL)}/auth/revalidate`, {
             headers: {Authorization: `Bearer ${token}`},
+            credentials: 'include'
         });
 
         const data = await response.json();
 
         if (data.token) {
-            NextResponse.json({ok: true}, {status: 200}).cookies.set({
+            const res = NextResponse.json({ok: true}, {status: 200});
+            res.cookies.set({
                 name: 'token',
                 value: data.token,
                 path: '/',
@@ -22,18 +24,20 @@ export async function GET(req: NextRequest) {
                 secure: true,
                 sameSite: 'strict'
             });
-            return
+            return res;
         } else {
-            NextResponse.json({ok: false}, {status: 200}).cookies.set({
+            const res = NextResponse.json({ok: false}, {status: 200});
+            res.cookies.set({
                 name: 'token',
                 value: '',
                 path: '/',
                 maxAge: 0
             });
+            return res;
         }
 
     } catch (error) {
-        console.error(error)
+        console.error(error);
         return NextResponse.json({ok: false}, {status: 500});
     }
 }

--- a/src/hooks/useRevalidateToken.ts
+++ b/src/hooks/useRevalidateToken.ts
@@ -8,11 +8,23 @@ export const useRevalidateToken = () => {
         const revalidate = async () => {
             try {
                 const res = await fetch('/api/revalidate', {
-                    method: 'GET'
+                    method: 'GET',
                 });
-                const data = await res.json();
-                
-                if (!data.ok) {
+                console.log({res})
+                if (!res.ok) {
+                    throw new Error(`HTTP error! status: ${res.status}`);
+                }
+
+                const contentType = res.headers.get('content-type');
+
+                if (contentType?.includes('application/json')) {
+                    const data = await res.json();
+
+                    if (!data.ok) {
+                        router.push('/login');
+                    }
+                } else {
+                    // No hay JSON, asumir token inválido o error inesperado
                     router.push('/login');
                 }
             } catch (error) {


### PR DESCRIPTION
Refactored the `useRevalidateToken` hook and `revalidate` API endpoint to include consistent response handling and error logging. Ensured `credentials: 'include'` is used and improved handling for non-JSON responses